### PR TITLE
Do not print payload if there is none

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -87,12 +87,12 @@ internals.utility = {
         let requestPayload = '';
         let responsePayload = '';
 
-        if (settings.requestPayload && typeof event.requestPayload === 'object') {
+        if (settings.requestPayload && typeof event.requestPayload === 'object' && event.requestPayload) {
             const request = SafeStringify(event.requestPayload);
             requestPayload = ` \n Request: ${request}`;
         }
 
-        if (settings.responsePayload && typeof event.responsePayload === 'object') {
+        if (settings.responsePayload && typeof event.responsePayload === 'object' && event.responsePayload) {
             const response = SafeStringify(event.responsePayload);
             responsePayload = ` \n Response: ${response}`;
         }


### PR DESCRIPTION
If there is no payload event.payload is set to null. Check for this and do not print it.